### PR TITLE
correctly specify a fixed version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ COPY entrypoint.sh /entrypoint.sh
 RUN apk update &&\
     apk add curl &&\
     rm -rf /var/lib/apt/lists/* &&\
-    wget https://downloads.kalix.io/2.0.19/kalix_linux_amd64.tar.gz &&\
-    tar xzf kalix_linux_amd64.tar.gz &&\
+    VERSION="2.0.19" &&\
+    wget https://downloads.kalix.io/${VERSION}/kalix_linux_amd64_${VERSION}.tar.gz &&\
+    tar xzf kalix_linux_amd64_${VERSION}.tar.gz &&\
     mv kalix /bin
 
 ## Set the entry point when the container starts


### PR DESCRIPTION
When using a fixed version, it needs to be put on the filename, as well.

Refs
- #14 
- https://github.com/lightbend/kalix-action/pull/8/files